### PR TITLE
index: clarify that ARMv7 is deprecated

### DIFF
--- a/user-docs/modules/ROOT/pages/index.adoc
+++ b/user-docs/modules/ROOT/pages/index.adoc
@@ -13,7 +13,7 @@ The Fedora IoT images also have excellent support for container-focused workflow
 
 If you are looking for a graphical desktop environment based on OSTree and designed for developers, look at https://silverblue.fedoraproject.org/[Fedora Silverblue].
 
-If you are looking for a traditional dnf based operating system for your ARM device, look at https://arm.fedoraproject.org/[Fedora ARM]
+If you are looking for a traditional dnf based operating system for your ARM device, look at https://arm.fedoraproject.org/[Fedora ARM] or at https://alt.fedoraproject.org/alt/[Alternative architectures supported by Fedora], but please note that Fedora Linux on ARMv7 (also known as arm32 or armhfp) is now deprecated.
 
 If you are looking for a lightweight yet powerful and scalable core OS for your Internet of Things project, you came to the right place! xref:getting-started.adoc[Get Started with Fedora IoT]!
 


### PR DESCRIPTION
The docs should note that when a user is looking for a traditional dnf based OS the link pointing to
https://arm.fedoraproject.org/ provides a OS that is deprecated.

This PR updates the index page adding that info and giving a pointer to https://alt.fedoraproject.org/alt/