### PR TITLE
Doc cleanups and navigation fixes

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -5,13 +5,13 @@ content:
   sources:
     - url: .
       branches: HEAD
-      start_path: user-docs 
+      start_path: user-docs
     - url: .
       branches: HEAD
       start_path: wg-docs
 ui:
   bundle:
-    url: https://asamalik.fedorapeople.org/ui-bundle.zip
+    url: https://gitlab.com/fedora/docs/docs-website/ui-bundle/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
     snapshot: true
   default_layout: with_menu
 output:

--- a/user-docs/modules/ROOT/nav.adoc
+++ b/user-docs/modules/ROOT/nav.adoc
@@ -20,3 +20,4 @@
 ** xref:admin-tasks.adoc[Administration Tasks]
 * xref:contributing.adoc[Contributing & Reporting Bugs]
 * xref:reference-platforms.adoc[Reference Platforms]
+* xref:prd.adoc[Product Requirements Document]

--- a/user-docs/modules/ROOT/pages/contributing.adoc
+++ b/user-docs/modules/ROOT/pages/contributing.adoc
@@ -10,7 +10,7 @@ If you're interested in joining the Fedora IoT Working Group, check out the xref
 == Reporting IoT bugs
 
 If you are seeing issues with software that is included in the Fedora IoT Edition that is not necessarily specific to IoT the bug should be reported against the specific Fedora component.
-There's details on how to do that in the xref:quick-docs::howto-file-a-bug.adoc[how to file a bug] doc.
+There's details on how to do that in the https://docs.fedoraproject.org/en-US/quick-docs/bugzilla-file-a-bug/[how to file a bug] doc.
 
 If you know which component the bug is in, file a bug in https://bugzilla.redhat.com[Red Hat Bugzilla] against the _Fedora_ product and the component in question.
 Set the bug to block the https://bugzilla.redhat.com/show_bug.cgi?id=IoT[IoT Bugzilla tracker].

--- a/wg-docs/modules/ROOT/nav.adoc
+++ b/wg-docs/modules/ROOT/nav.adoc
@@ -1,5 +1,5 @@
 * xref:index.adoc[Welcome]
-* xref:prd.adoc[Product Requirement Doc]
+* xref:iot::prd.adoc[Product Requirement Document]
 * xref:iot::index.adoc[User Docs]
 * Historical docs
 ** xref:edition-promotion.adoc[Edition Promotion]

--- a/wg-docs/modules/ROOT/pages/edition-promotion.adoc
+++ b/wg-docs/modules/ROOT/pages/edition-promotion.adoc
@@ -8,9 +8,9 @@ Historical information is included below for reference, although it is now incre
 [cols="8,2,8",options="header"]
 |=====
 | Requirement | Status | Additional information
-| The candidate Edition must be backed by a team that holds regular public meetings | https://docs.fedoraproject.org/en-US/iot/contributing/#_communications[DONE] | 
-| The candidate Edition must get trademark approval from the Fedora Council | https://pagure.io/Fedora-Council/tickets/issue/277[DONE] | 
-| The candidate Edition must have a product requirements document | https://docs.fedoraproject.org/en-US/iot/prd/[DONE] | 
+| The candidate Edition must be backed by a team that holds regular public meetings | https://docs.fedoraproject.org/en-US/iot/contributing/#_communications[DONE] |
+| The candidate Edition must get trademark approval from the Fedora Council | https://pagure.io/Fedora-Council/tickets/issue/277[DONE] |
+| The candidate Edition must have a product requirements document | https://docs.fedoraproject.org/en-US/iot/prd/[DONE] |
 |=====
 
 === Process
@@ -20,7 +20,7 @@ Historical information is included below for reference, although it is now incre
 [cols="8,2,8",options="header"]
 |====
 | **Requirement** | **Status** | **Additional information**
-| Review test cases and release criteria with QA | https://fedoraproject.org/wiki/Category:IoT_Acceptance_Test_Cases[DONE] | 
+| Review test cases and release criteria with QA | https://fedoraproject.org/wiki/Category:IoT_Acceptance_Test_Cases[DONE] |
 | Work with Release Engineering | DONE | Composes are being produced
 |====
 
@@ -61,7 +61,7 @@ Historical information is included below for reference, although it is now incre
 *** Content from IoT team
 *** Design from ??? (will ask OSPO)
 *** Integration work into new web system from CPE
-*** Parity with existing iot.fedoraproject.org for automatic updates when new images come out with 
+*** Parity with existing iot.fedoraproject.org for automatic updates when new images come out with
 ** New content for front page presenting the edition
 *** Any text from CPE team
 *** Design to match existing front page


### PR DESCRIPTION
This fixes some broken links and navigation errors that existed when building the docs.  Additionally, this switches over to the official Fedora UI bundle.

See individual commits for details and rationale.