### PR TITLE
SOP branching: Add section for ansible related tasks at release

### DIFF
--- a/user-docs/modules/ROOT/pages/sop-branching-fedora-iot.adoc
+++ b/user-docs/modules/ROOT/pages/sop-branching-fedora-iot.adoc
@@ -183,6 +183,27 @@ Review the changes and if satisfied, push to your fork and open a pull request f
 * check to make sure the Fedora IoT tag has been created in koji. To verify you will need to install the `koji` package in Fedora
 ** Verify the tags are listed for the new branches `koji list-tags|grep f*-iot`
 
-* ensure the signing key has been updated in ansible (look for the iot portion)
+* ensure the signing key has been updated in Ansible (look for the iot portion)
 ** https://pagure.io/fedora-infra/ansible
 ** As of Fedora 40 you can find the relevant section https://pagure.io/fedora-infra/ansible/blob/main/f/roles/robosignatory/templates/robosignatory.toml.j2=_434[here].
+* Make sure to update Ansible and create a cron job for the development (devel) release. You can find cron jobs https://pagure.io/fedora-infra/ansible/blob/main/f/roles/releng/files[here]. 
+
+You will need to create the file as it gets removed at Final. Example for `devel-iot` (IMPORTANT - Make sure to update the branched used, in the example it's `f41`):
+
+----
+# IoT devel compose
+MAILTO=releng-cron@lists.fedoraproject.org
+00 14 * * * root touch /tmp/fedora-compose-devel-iot && TMPDIR=`mktemp -d /tmp/devel.XXXXXX` && cd $TMPDIR && git clone https://pagure.io/fedora-iot/pungi-iot.git && cd pungi-iot && git checkout f41 && ./twoweek-nightly.sh RC-$(date "+\%Y\%m\%d").0 && rm /tmp/fedora-compose-devel-iot
+----
+
+Add it to the IoT section of main.yml found https://pagure.io/fedora-infra/ansible/blob/main/f/roles/releng/tasks/main.yml[here]:
+
+----
+# put cron job in for IoT devel compose
+- name: IoT devel compose cron
+  ansible.builtin.copy:
+    src: devel-iot
+    dest: /etc/cron.d/devel-iot
+    mode: "644"
+  when: inventory_hostname.startswith('compose-iot01.iad2')
+----

--- a/user-docs/modules/ROOT/pages/sop-create-release-candidates.adoc
+++ b/user-docs/modules/ROOT/pages/sop-create-release-candidates.adoc
@@ -92,6 +92,10 @@ sed -i 's|fedora/linux/development/41|fedora/linux/releases/41|g' config.ini
 
 Review changes and open a pull request for peer review.
 
+==== Update Automated compose
+
+Ensure the cron job used to automate the compose for `stable-iot` is updated to point to the correct https://pagure.io/fedora-infra/ansible/blob/main/f/roles/releng/files/stable-iot[branch] for the new stable release and delete the cronjob used for the development release, `devel-iot`. 
+
 ==== Release compose
 
 After the changes have been merged, complete the GA compose. Once completed, open a ticket with https://pagure.io/releng/issues[Release Engineering] to sign the deliverables. A request https://pagure.io/releng/issue/11677[example] from Fedora 39.


### PR DESCRIPTION

This adds some notes to release milestones for ansible and cron jobs used to automate the IoT compose 