### PR TITLE
Fix embedded image

### DIFF
--- a/user-docs/modules/ROOT/pages/fdo-the-process-of-device-onboarding.adoc
+++ b/user-docs/modules/ROOT/pages/fdo-the-process-of-device-onboarding.adoc
@@ -95,6 +95,7 @@ be executed.
 
 The following diagram represents the FIDO device onboarding workflow:
 .Deploying Fedora IoT in non-network environment
+
 image::FDO_Process.png[FDO device onboarding]
 
 At the *Device Initialization*, the device contacts the Manufacturing server to


### PR DESCRIPTION
A missing newline character was preventing the FDO_Process.png image from displaying. This commit fixes this error.