### PR TITLE
Update link to images download page

### DIFF
--- a/user-docs/modules/ROOT/pages/fdo-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/fdo-device-setup.adoc
@@ -20,7 +20,7 @@ include::_attributes.adoc[]
                --permanent
 # systemctl restart firewalld
 ....
-* You have downloaded the link:http://iot.fedoraproject.org[Simplified Provisioner ISO image] and booted the device from it by
+* You have downloaded the link:https://fedoraproject.org/iot/download[Simplified Provisioner ISO image] and booted the device from it by
 using one of the methods described in xref:booting-the-simplified-provisioner.adoc[Booting the Simplified Provisioner].
 
 

--- a/user-docs/modules/ROOT/pages/getting-started.adoc
+++ b/user-docs/modules/ROOT/pages/getting-started.adoc
@@ -22,7 +22,7 @@ The Fedora IoT base image should be able to run with less resources, but of cour
 
 == Download Image
 
-Fedora IoT images are available for download at the https://getfedora.org/en/iot/[landing page]. There are three options available to install IoT on your device:
+Fedora IoT images are available for download at the https://fedoraproject.org/iot/download[Download Fedora IoT page]. There are three options available to install IoT on your device:
 
 * Anaconda installer ISO (Fedora-IoT-ostree-XX.XX.iso ) - The traditional Fedora installer, offers an interactive graphical installation tool to configure most aspects of the system including filesystem, users and passwords.
 * Disk image (Fedora-IoT-raw-XX.XX.raw.xz) - A pre-built disk image suitable for single board computers (SBC's) like the Raspberry Pi 4.

--- a/user-docs/modules/ROOT/pages/ignition-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/ignition-device-setup.adoc
@@ -6,7 +6,7 @@ include::_attributes.adoc[]
 == Prerequisites
 
 * You have xref:creating-an-ignition-configuration-file.adoc[created an Ignition configuration file] and is accessible via HTTP/HTTPS.
-* You have downloaded the link:http://iot.fedoraproject.org[Simplified Provisioner ISO image] and booted the device from it by
+* You have downloaded the link:https://fedoraproject.org/iot/download[Simplified Provisioner ISO image] and booted the device from it by
 using one of the methods described in xref:booting-the-simplified-provisioner.adoc[Booting the Simplified Provisioner].
 
 

--- a/user-docs/modules/ROOT/pages/obtaining-images.adoc
+++ b/user-docs/modules/ROOT/pages/obtaining-images.adoc
@@ -1,6 +1,6 @@
 = Obtaining Images
 
-Available images for download are described on the IoT https://iot.fedoraproject.org[landing page].
+Available images for download are described on the https://fedoraproject.org/iot/download[Download Fedora IoT page].
 
 == Why the Fedora IoT Image
 
@@ -23,4 +23,4 @@ If you are looking for a graphical desktop environment based on OSTree and desig
 
 If you are looking for a traditional dnf based operating system for your ARM device, visit https://fedoraproject.org/[Fedora].
 
-If you are looking for a lightweight yet powerful and scalable core OS for your Internet of Things project, you came to the right place! https://iot.fedoraproject.org/[Download the images now]!
+If you are looking for a lightweight yet powerful and scalable core OS for your Internet of Things project, you came to the right place! https://fedoraproject.org/iot/download[Download the images now]!


### PR DESCRIPTION
In 2020, https://iot.fedoraproject.org/ started redirecting to https://getfedora.org/iot/, then to https://fedoraproject.org/iot/, and the images download links moved from the IoT landing page to https://fedoraproject.org/iot/download.