### PR TITLE
Remove :toc: attribute

### DIFF
--- a/user-docs/modules/ROOT/pages/admin-tasks.adoc
+++ b/user-docs/modules/ROOT/pages/admin-tasks.adoc
@@ -1,5 +1,4 @@
 = Administration Tasks
-:toc:
 
 Additional tasks mimic any other Linux administration tasks and use available utilities included in the Fedora distribution.
 Some tasks are described below with specific links to other Fedora Documentation or upstream documentation.

--- a/user-docs/modules/ROOT/pages/applying-updates-UG.adoc
+++ b/user-docs/modules/ROOT/pages/applying-updates-UG.adoc
@@ -1,5 +1,4 @@
 = Updates and Rollbacks
-:toc:
 
 NOTE: The latest image builds are available https://download.fedoraproject.org/pub/alt/iot/[here].
 

--- a/user-docs/modules/ROOT/pages/booting-the-simplified-provisioner.adoc
+++ b/user-docs/modules/ROOT/pages/booting-the-simplified-provisioner.adoc
@@ -1,7 +1,6 @@
 include::_attributes.adoc[]
 
 = Boot the Simplified Provisioner
-:toc:
 
 == Boot from the Simplified Provisioner ISO
 

--- a/user-docs/modules/ROOT/pages/build-container.adoc
+++ b/user-docs/modules/ROOT/pages/build-container.adoc
@@ -1,5 +1,4 @@
 = Build a Container with a Containerfile
-:toc:
 
 == Creating the Containerfile
 If a container does not already exist for your application, one can be built for your device. 

--- a/user-docs/modules/ROOT/pages/fdo-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/fdo-device-setup.adoc
@@ -1,7 +1,6 @@
 include::_attributes.adoc[]
 
 = Setup a device by using FDO and the Simplified Provisioner
-:toc:
 
 == Prerequisites
 

--- a/user-docs/modules/ROOT/pages/ignition-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/ignition-device-setup.adoc
@@ -1,7 +1,6 @@
 include::_attributes.adoc[]
 
 = Setup a device by using Ignition and the Simplified Provisioner
-:toc:
 
 == Prerequisites
 

--- a/user-docs/modules/ROOT/pages/physical-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/physical-device-setup.adoc
@@ -1,5 +1,4 @@
 = Setting up a Physical Device
-:toc:
 
 == Gather the Physical Components
 

--- a/user-docs/modules/ROOT/pages/rebasing.adoc
+++ b/user-docs/modules/ROOT/pages/rebasing.adoc
@@ -1,5 +1,4 @@
 = Rebasing to New Versions
-:toc:
 
 The `rpm-ostree rebase` command allows you to switch between multiple branches.
 The `ostree remote` command allows you to view and change repository options.

--- a/user-docs/modules/ROOT/pages/run-container.adoc
+++ b/user-docs/modules/ROOT/pages/run-container.adoc
@@ -1,5 +1,4 @@
 = Images and Containers
-:toc:
 
 == Finding Images
 

--- a/user-docs/modules/ROOT/pages/virtual-machine-setup.adoc
+++ b/user-docs/modules/ROOT/pages/virtual-machine-setup.adoc
@@ -1,5 +1,4 @@
 = Setting up a Virtual Machine
-:toc:
 
 == Enable UEFI support for KVM virtual machines
 Fedora IoT requires UEFI, take a look at this wiki page on how to make it available for your VM: https://docs.fedoraproject.org/en-US/quick-docs/uefi-with-qemu/


### PR DESCRIPTION
As mentionned in https://docs.fedoraproject.org/en-US/fedora-docs/contributing-docs/asciidoc-markup/#_table_of_content, there is no need to add the `:toc:` attribute, which adds a duplicate table of content to the document.

The table of contents is already displayed to the right of the page.