### PR TITLE
Update Fedora Silverblue URL

### DIFF
--- a/user-docs/modules/ROOT/pages/index.adoc
+++ b/user-docs/modules/ROOT/pages/index.adoc
@@ -11,13 +11,13 @@ The Fedora IoT images also have excellent support for container-focused workflow
 
 == Is Fedora IoT for you?
 
-If you are looking for a graphical desktop environment based on OSTree and designed for developers, look at https://silverblue.fedoraproject.org/[Fedora Silverblue].
+If you are looking for a graphical desktop environment based on OSTree and designed for developers, look at https://fedoraproject.org/atomic-desktops/silverblue/[Fedora Silverblue].
 
 If you are looking for a traditional dnf based operating system for your device, visit https://fedoraproject.org/[Fedora].
 
-If you are looking for a lightweight yet powerful and scalable core OS for your Internet of Things project, you came to the right place! xref:getting-started.adoc[Get Started with Fedora IoT]!
+If you are after an OS for Kubernetes, there is https://fedoraproject.org/en/coreos/[Fedora CoreOS].
 
-If you are after an OS for Kubernetes there is https://fedoraproject.org/en/coreos/[Fedora CoreOS]
+If you are looking for a lightweight yet powerful and scalable core OS for your Internet of Things project, you came to the right place! xref:getting-started.adoc[Get Started with Fedora IoT]!
 
 == Contribute to Fedora IoT Edition
 For communication and contributing please see the xref:contributing.adoc[Contributing and Reporting Bugs] section.


### PR DESCRIPTION
Update Fedora Silverblue URL.

Also move FCOS before Fedora IoT, to end with "you came to the right place".