### PR TITLE
Add a note about Zezere retirement.

### DIFF
--- a/user-docs/modules/ROOT/pages/ignition-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/ignition-device-setup.adoc
@@ -1,4 +1,13 @@
 include::_attributes.adoc[]
+= Setup a device by using Ignition and a Raw disk image
+
+== Prerequisites
+
+* You have xref:creating-an-ignition-configuration-file.adoc[created an Ignition configuration file] and is accessible via HTTP/HTTPS.
+* You have downloaded a link:https://fedoraproject.org/iot/download[Raw disk image] and copied to media for your device.
+
+== Edit the boot parameters
+As the device boots, edit the kernel args and add the url to your ignition config, for example: `ignition.config.url=http://192.168.122.1/fiot.ign`
 
 = Setup a device by using Ignition and the Simplified Provisioner
 
@@ -35,7 +44,7 @@ menuentry 'Install Fedora {FedoraVersion}' --class fedora --class gnu-linux --cl
 ....
 * Boot the menu entry by pressing *"[Ctrl-x]"* to boot and install the IoT device
 
-== Verifying the installation
+= Verifying the installation
 
 Once the installation has finished and the device has rebooted you should be able to login with the user
 configured within the ignition file:

--- a/user-docs/modules/ROOT/pages/ignition.adoc
+++ b/user-docs/modules/ROOT/pages/ignition.adoc
@@ -1,5 +1,7 @@
 = Setting up a Device with Zezere
 
+IMPORTANT: Zezere has been retired as of Fedora 42, for device configuration in Fedora 42+ use xref:creating-an-ignition-configuration-file.adoc[Ignition], xref:fdo-the-process-of-device-onboarding[FDO] or copy your SSH key using xref:arm-image-installer[arm-image-installer]. 
+
 The disk images do not have a pre-configured user or any passwords set for security reasons. To use the deployment you will need to add your SSH key to the root account using the provisioning service - Zezere.
 
 == Using the Zezere Provisioning Server

--- a/user-docs/modules/ROOT/pages/physical-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/physical-device-setup.adoc
@@ -59,7 +59,7 @@ $ dmesg -w
 ----
 
 === Scripted image transfer with `arm-image-installer` 
-
+<<arm-image-installer>>
 Install the `arm-image-installer` package:
 
 ----


### PR DESCRIPTION
Zezere is being retired as of Fedora 42, add a note to the top to refer other methods of configuration.