### PR TITLE
Adds another bootc example to documentation

### DIFF
--- a/user-docs/modules/ROOT/nav.adoc
+++ b/user-docs/modules/ROOT/nav.adoc
@@ -29,6 +29,8 @@
 ** xref:rebasing.adoc[Rebasing to New Versions]
 ** xref:admin-tasks.adoc[Administration Tasks]
 ** xref:fedora-iot-bootc.adoc[Fedora IoT Bootc]
+*** xref:fedora-iot-bootc-pmachine-example.adoc[Bootc Podman Machine Example]
+*** xref:fedora-iot-bootc-quay-example.adoc[Bootc Quay Example]
 * xref:contributing.adoc[Contributing & Reporting Bugs]
 * xref:reference-platforms.adoc[Reference Platforms]
 * xref:prd.adoc[Product Requirement Document]

--- a/user-docs/modules/ROOT/pages/fedora-iot-bootc-pmachine-example.adoc
+++ b/user-docs/modules/ROOT/pages/fedora-iot-bootc-pmachine-example.adoc
@@ -1,0 +1,54 @@
+= Fedora IoT Bootc Image Example with Podman Machine
+
+This example walks through building and booting a Fedora IoT bootc image in a Podman machine. 
+
+NOTE: This example is based on the Fedora bootc documentation about building scratch images; reference the upstream docs 
+https://docs.fedoraproject.org/en-US/bootc/building-from-scratch/#_using_bootc_base_imagectl_build_rootfs[here] for the latest version/information.
+
+To start, create a `Containerfile.custom` with the following contents:
+----
+FROM quay.io/fedora-testing/fedora-bootc:rawhide-standard as builder
+RUN /usr/libexec/bootc-base-imagectl build-rootfs --manifest=fedora-iot /target-rootfs
+
+FROM scratch
+COPY --from=builder /target-rootfs/ /
+LABEL containers.bootc 1
+ENV container=oci
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]
+----
+
+Initialize your Podman machine using the following command. You may skip this step if you already have a podman machine.
+----
+podman machine init
+----
+
+Grant your Podman machine the permissions necessary to run your Fedora IoT bootc image using:
+----
+podman machine set --rootful
+----
+
+Start your Podman machine using
+----
+podman machine start
+----
+
+Use the following command to build your `fedora-iot` image:
+----
+podman -c podman-machine-default-root build --cap-add=all --security-opt=label=disable \
+--device /dev/fuse -t localhost/fedora-iot -f Containerfile.custom .
+----
+
+After building the `localhost/fedora-iot` image, you should be able to see it in your Podman machine's list of images. Use the following command to check:
+----
+podman -c podman-machine-default-root images
+----
+
+NOTE: The next step uses `podman-bootc`. If you need to install `podman-bootc`, please follow the instructions in the 
+https://github.com/containers/podman-bootc[podman-bootc repository]
+
+You're now ready to boot a virtual machine using your new Fedora IoT bootc image. The command below will boot a VM in your current terminal window, 
+allowing you to test everything that Fedora IoT bootc images have to offer:
+----
+podman-bootc run --filesystem=ext4 localhost/fedora-iot
+----

--- a/user-docs/modules/ROOT/pages/fedora-iot-bootc-quay-example.adoc
+++ b/user-docs/modules/ROOT/pages/fedora-iot-bootc-quay-example.adoc
@@ -1,0 +1,121 @@
+= Fedora IoT Bootc Image Example with Quay
+
+== Building and Booting a Fedora IoT Bootc Image
+
+This example walks through building and booting a Fedora IoT bootc image using Quay.io, as well as pushing an update to a booted 
+Fedora IoT system.
+
+NOTE: This example is based on the Fedora bootc documentation about building scratch images; reference the upstream docs 
+https://docs.fedoraproject.org/en-US/bootc/building-from-scratch/#_using_bootc_base_imagectl_build_rootfs[here] for the latest version/information.
+
+NOTE: This example assumes the user has a Quay account with the ability to create custom repositories.
+
+To start, create a `Containerfile.custom` with the following contents:
+----
+FROM quay.io/fedora-testing/fedora-bootc:rawhide-standard as builder
+RUN /usr/libexec/bootc-base-imagectl build-rootfs --manifest=fedora-iot /target-rootfs
+
+FROM scratch
+COPY --from=builder /target-rootfs/ /
+LABEL containers.bootc 1
+ENV container=oci
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]
+----
+
+You're now ready to build a Fedora IoT bootc image using the custom containerfile you made earlier. Use this command:
+----
+podman build --cap-add=all --security-opt=label=type:container_runtime_t \
+--device /dev/fuse -t localhost/fedora-iot -f Containerfile.custom .
+----
+
+Then, tag your Fedora IoT bootc image:
+----
+podman tag localhost/fedora-iot:latest quay.io/[quay repository name]:fedora-iot
+----
+
+Before pushing to Quay.io, you may need to log in:  
+----  
+podman login quay.io  
+---- 
+
+Push your new Fedora IoT bootc image to Quay.io using the following command. Note that you may need to log in again:
+----
+podman push quay.io/[quay repository name]:fedora-iot
+----
+
+NOTE: The next step uses `podman-bootc`. If you need to install `podman-bootc`, please follow the instructions in the 
+https://github.com/containers/podman-bootc[podman-bootc repository]
+
+Now, boot your Fedora IoT bootc image. Open a new terminal window and run:
+----
+podman-bootc run --filesystem=ext4 quay.io/[quay repository name]:fedora-iot
+----
+
+`podman-bootc` will pull your image and boot it inside a VM in the terminal window, 
+allowing you to test everything Fedora IoT bootc images have to offer.
+
+== Pushing an Update to your Fedora IoT bootc system
+
+After completing the tutorial above, you now have a functional Fedora IoT bootc system! But what if you need to make a change?
+Updating a bootc system is remarkably simple -- just follow the steps below. 
+
+NOTE: This tutorial assumes you have just completed the above tutorial, and have access to a booted Fedora IoT bootc system.
+
+First, navigate to your cloned Fedora Bootc Base Images repository and create a containerfile named `Containerfile.fix` with your desired changes. 
+
+Next, rebuild your `localhost/fedora-iot` image using the new containerfile:
+----
+podman build --cap-add=all --security-opt=label=type:container_runtime_t \
+--device /dev/fuse -t localhost/fedora-iot -f Containerfile.fix .
+----
+
+Tag your updated Fedora IoT bootc image:
+----
+podman tag localhost/fedora-iot:latest quay.io/[quay repository name]:fedora-iot
+----
+
+Before pushing to Quay.io, you may need to log in:
+----
+podman login quay.io
+----
+
+Push your updated Fedora IoT bootc image to Quay.io, using the command below:
+----
+podman push quay.io/[quay repository name]:fedora-iot
+----
+
+After successfully pushing, switch back to your virtual machine running your Fedora IoT bootc image. 
+Download and queue the updated image for your next reboot:
+----
+bootc upgrade
+----
+
+Run the following command to see your updated image staged for the next reboot:
+----
+bootc status
+----
+
+Reboot your Fedora IoT bootc system and use your new updated image:
+----
+reboot
+----
+
+After rebooting, you may need to ssh back into your Fedora IoT bootc system. To do so, first list all podman-bootc
+VMs: 
+----
+podman-bootc list
+----
+
+Then find the ID of your desired machine and run the following:
+----
+podman-bootc ssh [ID]
+----
+
+After reconnecting, run check the status again:
+----
+bootc status
+----
+
+Your updated image should now show up 
+as `Booted`, and the previous image as `Rollback`. You have successfully updated your Fedora IoT bootc system!

--- a/user-docs/modules/ROOT/pages/fedora-iot-bootc.adoc
+++ b/user-docs/modules/ROOT/pages/fedora-iot-bootc.adoc
@@ -1,7 +1,5 @@
 = Fedora IoT Bootc Images
 
-== Getting Familiar with Bootc
-
 As part of Fedora's initiative towards bootable containers, you can now create Fedora IoT bootc images. These images use standard
 OCI/Docker containers as transport but contain all components needed to boot a Fedora IoT system. This allows you to ship updates to 
 your Fedora IoT system using container images.
@@ -11,62 +9,3 @@ and ease of maintenance provided by bootc.
 
 For more information, please check out the https://docs.fedoraproject.org/en-US/bootc/[official bootc documentation], as well as the 
 https://gitlab.com/fedora/bootc/base-images[Fedora Bootc Base Images Git repository].
-
-== Fedora IoT Bootc Image Example
-
-This example walks through building and booting a Fedora IoT bootc image in a Podman machine. 
-
-To start, create a clone of the https://gitlab.com/fedora/bootc/base-images[Fedora Bootc Base Images] Git repository. This includes the Fedora
-IoT package manifest we will use to create out Fedora IoT bootc image.
-
-Within this clone, create a `Containerfile.custom` with the following contents:
-----
-FROM localhost/fedora-bootc as builder
-RUN /usr/libexec/bootc-base-imagectl build-rootfs --manifest=fedora-iot /target-rootfs
-
-FROM scratch
-COPY --from=builder /target-rootfs/ /
-LABEL containers.bootc 1
-ENV container=oci
-STOPSIGNAL SIGRTMIN+3
-CMD ["/sbin/init"]
-----
-
-Initialize your Podman machine using the following command. You may skip this step if you already have a podman machine.
-----
-podman machine init
-----
-
-Grant your Podman machine the permissions necessary to run your Fedora IoT bootc image using:
-----
-podman machine set --rootful
-----
-
-Start your Podman machine using
-----
-podman machine start
-----
-
-Next, create a `localhost/fedora-bootc` image using the command below. This is required for building your Fedora IoT bootc image, as the 
-containerfile you created uses `localhost/fedora-bootc` as builder:
-----
-podman -c podman-machine-default-root build --cap-add=all --security-opt=label=disable \
---device /dev/fuse -t localhost/fedora-bootc .
-----
-
-You've now created a `localhost/fedora-bootc` image and have all the tools to build your `fedora-iot` image. Use the following command to do so:
-----
-podman -c podman-machine-default-root build --cap-add=all --security-opt=label=disable \
---device /dev/fuse -t localhost/fedora-iot -f Containerfile.custom
-----
-
-After building the `localhost/fedora-iot` image, you should be able to see it in your Podman machine's list of images. Use the following command to check:
-----
-podman -c podman-machine-default-root images
-----
-
-You're now ready to boot a virtual machine using your new Fedora IoT bootc image. The command below will boot a VM in your current terminal window, 
-allowing you to test everything that Fedora IoT bootc images have to offer:
-----
-podman-bootc run --filesystem=xfs localhost/fedora-iot
-----


### PR DESCRIPTION
Follow up to #95.

- Adds another bootc example to documentation, this time using quay and including the steps to update a booted system.
- Fixes filesystem misrepresentation. Filesystem is now correctly stated as `ext4`