### PR TITLE
Update booting-the-simplified-provisioner.adoc

### DIFF
--- a/user-docs/modules/ROOT/pages/booting-the-simplified-provisioner.adoc
+++ b/user-docs/modules/ROOT/pages/booting-the-simplified-provisioner.adoc
@@ -1,13 +1,23 @@
 include::_attributes.adoc[]
 
-= Boot the Simplified Provisioner
+= Quick firmware update with the Coreos Installer
 
-== Boot from the Simplified Provisioner ISO
+== Overview 
+The Coreos Installer tool, run from the simplified provisioner ISO file, allows technicians to update the firmware on a controller device for immediate use.
 
-* If you are using physical devices with a CD-ROM unit:
-** Burn the downloaded Simplified Provisioner ISO to a CD-ROM
-** Use the CD-ROM to boot the IoT device from it.
-* If you are using Virtual Machines, you can use the `virt-install`
+It does this by bypassing the usual user setup process and jumping to a direct install of a preconfigured OS "snapshot".
+
+To initiate this process for physical hardware, first either save the ISO file to a flash drive and then insert it into the controller or edge device you'd like to update, Alternatively for virtual machine server setups, simply run an install command from the Linux command prompt.
+
+== Installing with a USB flash drive
+
+1. Copy the ISO file to a USB flash drive with no less than 8 GB of storage capacity.
+2. Connect the USB flash drive to the port of the controller you wish to update the firmware on.
+
+
+== Installing on virtual machines for server
+
+1. Use the `virt-install`
 command to boot from the Simplified Provisioner ISO.
 +
 [subs="attributes"]
@@ -21,16 +31,10 @@ command to boot from the Simplified Provisioner ISO.
                --disk pool=default,size=30 \
                --cdrom {FedoraSimplifiedProvisionerISO}
 ....
-
-== Boot the Simplified Provisioner from an USB Flash Drive
-
-* Copy the ISO image file to a USB flash drive (You will need a 8 GB USB flash drive at least)
-* Connect the USB flash drive to the port of the computer you want to boot.
-* Boot the device from the USB flash drive.
-
+ 
 == Boot the Simplified Provisioner from UEFI HTTP Boot
 
-* Copy the contents of the Simplified Provisioner ISO to a directory
+1. Copy the contents of the Simplified Provisioner ISO to a directory
 +
 [subs="attributes"]
 ....

--- a/user-docs/modules/ROOT/pages/fdo-installing-configuring-and-running-the-owner-server.adoc
+++ b/user-docs/modules/ROOT/pages/fdo-installing-configuring-and-running-the-owner-server.adoc
@@ -8,7 +8,7 @@ during the first device boot. The Rendezvous server then matches the device
 UUID with the target platform or cloud and informs the device about which Owner
 server endpoint the device must use.
 
-.Prerequisites
+== Prerequisites
 
 * The device where the server will be deployed has a Trusted Platform Module
 (TPM) device to encrypt the disk. If not, you will get an error when booting
@@ -16,7 +16,7 @@ the Fedora IoT device.
 * You created the `device_ca_cert.pem`, `owner_key.der`, and `owner_cert.pem`
 with keys and certificates and copied them into the `/etc/fdo/keys` directory.
 
-.Procedure
+== Procedure
 
 . Install the required RPMs in this server:
 +

--- a/user-docs/modules/ROOT/pages/ignition-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/ignition-device-setup.adoc
@@ -3,24 +3,23 @@ include::_attributes.adoc[]
 
 === Prerequisites
 
-* You have xref:creating-an-ignition-configuration-file.adoc[created an Ignition configuration file] and is accessible via HTTP/HTTPS.
-* You have downloaded a link:https://fedoraproject.org/iot/download[Raw disk image] and copied to media for your device.
+* You have xref:creating-an-ignition-configuration-file.adoc[created an Ignition configuration file] that is accessible via HTTP/HTTPS.
+* You have downloaded a link:https://fedoraproject.org/iot/download[Raw disk image] and copied it to your device's storage medium.
 
 === Edit the boot parameters
-As the device boots, edit the kernel args and add the url to your ignition config, for example: `ignition.config.url=http://192.168.122.1/fiot.ign`
+As the device boots, edit the kernel args and add the url to your ignition config. For example: `ignition.config.url=http://192.168.122.1/fiot.ign`
 
-== Setup a device by using Ignition and the Simplified Provisioner
+== Set up a device using Ignition and the Simplified Provisioner.
 
 === Prerequisites
 
-* You have xref:creating-an-ignition-configuration-file.adoc[created an Ignition configuration file] and is accessible via HTTP/HTTPS.
-* You have downloaded the link:https://fedoraproject.org/iot/download[Simplified Provisioner ISO image] and booted the device from it by
-using one of the methods described in xref:booting-the-simplified-provisioner.adoc[Booting the Simplified Provisioner].
+* You have xref:creating-an-ignition-configuration-file.adoc[created an Ignition configuration file] that is accessible via HTTP/HTTPS.
+* You have downloaded the link:https://fedoraproject.org/iot/download[Simplified Provisioner ISO image] and booted the device using it through one of the methods described in xref:booting-the-simplified-provisioner.adoc[Booting the Simplified Provisioner].
 
 
 === Edit the boot parameters
 
-Once device has been booted from the Simplified Provisioner the boot menu shows the
+Once the device has been booted from the Simplified Provisioner, the boot menu shows the
 following options:
 [subs="attributes"]
 ....
@@ -46,7 +45,7 @@ menuentry 'Install Fedora {FedoraVersion}' --class fedora --class gnu-linux --cl
 
 == Verifying the installation
 
-Once the installation has finished and the device has rebooted you should be able to login with the user
+Once the installation has finished and the device has rebooted, you should be able to log in with the user
 configured within the ignition file:
 [subs="attributes"]
 ....

--- a/user-docs/modules/ROOT/pages/obtaining-images.adoc
+++ b/user-docs/modules/ROOT/pages/obtaining-images.adoc
@@ -7,15 +7,15 @@ Available images for download are described on the https://fedoraproject.org/iot
 The use of https://ostree.readthedocs.io/en/latest/[OSTree] brings fully atomic upgrades, easy rollbacks and workflows that are familiar to users of immutable, image based servers.
 
 An OS image that is composed on the server side allows for testing the exact bits before they reach client systems, leading to more reliable updates.
-The GPG signed image based deployments scale well to very large numbers of clients.
-Updates are atomic so nothing changes until the device is rebooted and the rollback capability makes it easy to recover remotely if there is a failure during upgrade.
+The GPG-signed image-based deployments scale well to very large numbers of clients.
+Updates are atomic, so nothing changes until the device is rebooted. Consequently, the rollback capability makes it easy to recover remotely from failure during an upgrade.
 
-The Fedora IoT images work with https://rpm-ostree.readthedocs.io/en/latest/[rpm-ostree] which is a hybrid image/package system.
+The Fedora IoT images work with https://rpm-ostree.readthedocs.io/en/latest/[rpm-ostree], which is a hybrid image/package system.
 It supports package layering, which allows installation of RPMs for additional hardware support or applications.
 
 The Fedora IoT images also have excellent support for container-focused workflows.
 Containers allow you to separate core OS updates from application updates as well as test and deploy different versions of applications.
-The https://podman.io/[podman] daemon is light weight and ready for you to download or create containers for your home assistant, industrial gateways, or data storage and analytics.
+The https://podman.io/[podman] daemon is lightweight and ready for you to download or create containers for your home assistant, industrial gateways, or data storage and analytics.
 
 == Pick the Right Tool for the Job
 
@@ -23,4 +23,4 @@ If you are looking for a graphical desktop environment based on OSTree and desig
 
 If you are looking for a traditional dnf based operating system for your ARM device, visit https://fedoraproject.org/[Fedora].
 
-If you are looking for a lightweight yet powerful and scalable core OS for your Internet of Things project, you came to the right place! https://fedoraproject.org/iot/download[Download the images now]!
+If you are looking for a lightweight yet powerful and scalable core OS for your Internet of Things project, you have come to the right place! https://fedoraproject.org/iot/download[Download the images now]!

--- a/user-docs/modules/ROOT/pages/physical-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/physical-device-setup.adoc
@@ -16,8 +16,7 @@ For the Fedora disk images:
 
 === SD Card
 The Fedora IoT image is currently 4GB in size.
-The best speed class depends on the usage. 
-A faster speed class is better for writes but the trade off is slower read speed.
+The best speed class depends on the usage; a faster speed class is better for writes, but the trade-off is slower read speed.
 
 Documentation for your board may also recommend specific SD Card choices as well as required physical sizes for each device.
 

--- a/user-docs/modules/ROOT/pages/physical-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/physical-device-setup.adoc
@@ -4,7 +4,7 @@
 
 A list of currently tested devices is maintained in the xref:reference-platforms.adoc[Reference Platforms] page.
 
-Always reference the documentation of the board you have selected for assembly instructions and requirements. At a minimum you will need the board, a power source, and a microSD card. 
+Always reference the documentation of the board you have selected for assembly instructions and requirements. You will need the board, a power source, and a microSD card at a minimum. 
 
 === Network connection
 If the Fedora image lacks support for your wireless network devices, you must add it after installation. 

--- a/user-docs/modules/ROOT/pages/physical-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/physical-device-setup.adoc
@@ -15,17 +15,17 @@ For the Fedora disk images:
 * The Raspberry Pi WiFi is supported in the base image.
 
 === SD Card
-The Fedora IoT image is currently 4GB in size.
+The Fedora IoT image is currently 4GB.
 The best speed class depends on the usage; a faster speed class is better for writes, but the trade-off is slower read speed.
 
-Documentation for your board may also recommend specific SD Card choices as well as required physical sizes for each device.
+Documentation for your board may also recommend specific SD Card choices and mandate physical sizes for each device.
 
 * Raspberry Pi discusses card size and speed class in their https://www.raspberrypi.org/documentation/installation/sd-cards.md[SD Card Documentation].
 
-WARNING: The following procedures will overwrite everything on the micro SD card. Be sure to backup any data before continuing!
+WARNING: The following procedures will overwrite everything on the micro SD card. Be sure to back up any data before continuing!
 
 == Create a Bootable SD Card
-If you have not already xref:obtaining-images.adoc[downloaded the image], do so now and make a note of the download location and filename.
+If you have not already xref:obtaining-images.adoc[downloaded the image], do so now and note the download location and filename.
 
 === Determine the SD Card Device name
 

--- a/user-docs/modules/ROOT/pages/physical-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/physical-device-setup.adoc
@@ -7,7 +7,7 @@ A list of currently tested devices is maintained in the xref:reference-platforms
 Always reference the documentation of the board you have selected for assembly instructions and requirements. At a minimum you will need the board, a power source, and a microSD card. 
 
 === Network connection
-If support for your wireless network devices is not available in the Fedora image, it will have to be added after installation. 
+If the Fedora image lacks support for your wireless network devices, you must add it after installation. 
 You will need a wired connection to complete the installation of the xref:add-layered.adoc[layered package].
 
 For the Fedora disk images:

--- a/user-docs/modules/ROOT/pages/physical-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/physical-device-setup.adoc
@@ -7,8 +7,8 @@ A list of currently tested devices is maintained in the xref:reference-platforms
 Always reference the documentation of the board you have selected for assembly instructions and requirements. At a minimum you will need the board, a power source, and a microSD card. 
 
 === Network connection
-If support for your wireless network devices are not available in the Fedora image, it will have to be added after installation. 
-You will need a wired connection to complete the install of the xref:add-layered.adoc[layered package].
+If support for your wireless network devices is not available in the Fedora image, it will have to be added after installation. 
+You will need a wired connection to complete the installation of the xref:add-layered.adoc[layered package].
 
 For the Fedora disk images:
 

--- a/user-docs/modules/ROOT/pages/physical-device-setup.adoc
+++ b/user-docs/modules/ROOT/pages/physical-device-setup.adoc
@@ -44,7 +44,7 @@ mmcblk0         179:0    0  14.9G  0 disk
 └─mmcblk0p3     179:3    0   2.9G  0 part /run/media/user/cce2e189-9aee-4b3e-b031-aac9bdc632c9
 ...output omitted...
 ----
-* If you have the `udisks2` package installed you may find the `udisksctl` command helpful in determining the media device name. It will show the model and only the device name without the extra partition information. In this example, a 16GB SanDisk Ultra shows as 'SL16G':
+* If you have the `udisks2` package installed, you may find the `udisksctl` command helpful in determining the media device name. It will show the model and the device name without the extra partition information. In this example, a 16GB SanDisk Ultra shows as 'SL16G':
 ----
 $ udisksctl status 
 MODEL                     REVISION  SERIAL               DEVICE
@@ -52,7 +52,7 @@ MODEL                     REVISION  SERIAL               DEVICE
 SAMSUNG MZSLW1T0HMLH-000L1           S308NAAH501124       nvme0n1 
 SL16G                               0x51821336           mmcblk0 
 ----
-* Finally, the kernel messages will show the addition of a device. In a terminal window before inserting the device run:
+* Finally, the kernel messages will show the addition of a device. In a terminal window before inserting the device, run:
 ----
 $ dmesg -w
 ----


### PR DESCRIPTION
### Documentation Contribution: Refactoring "Simplified Provisioning" for Field Use

**Overview:** 
I am a technical writer with experience documenting Building Automation System (BAS) control software. I’ve begun drafting a revised version of the Simplified Provisioning guide to better align with a "Field Technician" workflow. My goal is to treat this process like a "Quick Firmware Update" to make it accessible to hardware-focused users.

**Key Changes Proposed:**
*   ** Overview** Added quick summary of the the steps and purpose.
*   **USB First:** Moved USB instructions to the top and removed CD burning section, as modern IoT/Edge controllers rarely use CD-ROMs.
*   **User-Centric Language:** Replaced developer jargon with functional terms like "preconfigured snapshot" and "controller".
*   **Simplified Layout:** Separated physical on-site steps from advanced server/VM commands and formatted as numbered procedural steps.

**Questions for SMEs:**
1. **Target Disk:** Since the install is "predetermined," what happens if the hardware uses an NVMe drive instead of the default `/dev/sda`? Where should the user change that argument?
2. **Success Indicators:** What does the technician see on the screen to know the "Zero-Touch" install is finished and it's safe to pull the USB?
3. **CD-ROM Support:** Given modern edge hardware, is the CD-ROM section still necessary, or can we archive it to simplify the guide?
